### PR TITLE
Remove footer repository attribution

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -47,10 +47,6 @@
 
         <footer class="footer">
             <p>&copy; {% now "Y" %} Justin Smethers</p>
-            <p>Developed with Django | Repository:</p>
-            <a href="https://github.com/JustinSmethers/website" target="_blank">
-            <img src="{% static 'blog/github-logo-white.png' %}" alt="GitHub" class="social-icon">
-            </a>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the footer attribution text and GitHub repository link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1e1e047b8832382abc0e00a383e9d