### PR TITLE
Move intro banner to top of blog index

### DIFF
--- a/blog/static/blog/css/style.css
+++ b/blog/static/blog/css/style.css
@@ -52,6 +52,71 @@ main {
     justify-content: center;
 }
 
+.intro-banner {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background-color: #2c2c2c;
+    color: #f9fafb;
+    border: 1px solid #3a3a3a;
+    border-radius: 16px;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+    padding: 24px;
+    margin: 30px auto 40px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.intro-banner-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    text-align: center;
+}
+
+.intro-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.intro-avatar img {
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid #dbd8cd;
+}
+
+.intro-text {
+    font-size: 18px;
+    line-height: 1.7;
+    max-width: 680px;
+    color: #f3f4f6;
+}
+
+@media (min-width: 768px) {
+    .intro-banner-content {
+        flex-direction: row;
+        align-items: center;
+        text-align: left;
+    }
+
+    .intro-avatar {
+        justify-content: flex-start;
+    }
+
+    .intro-avatar img {
+        width: 160px;
+        height: 160px;
+    }
+
+    .intro-text {
+        font-size: 20px;
+    }
+}
+
 .tag-list {
     display: flex;
     flex-wrap: wrap;
@@ -127,53 +192,14 @@ main {
     /* Flex container to hold the two sections */
     .flex-container {
         display: flex;
-        column-gap: 30px;
-        width: 55%; /* Adjust width as needed */
-        justify-content: center;
-        flex-direction: row;
-        vertical-align: top;
-    }
-
-    .top-bar {
-        display: flex;
         flex-direction: column;
         align-items: center;
-        background-color: #333;
-        color: #fff;
-        width: 40%;
-        border-radius: 8px; /* Rounded corners */
-        box-shadow: 0 6px 8px rgba(0,0,0,0.1);
-        padding: 20px;
-        border: 1px solid #dbd8cd; /* Adjust the color and thickness as desired */
-        border-radius: 8px; /* This rounds the corners. Adjust as desired. */
-        box-sizing: border-box;
-        box-shadow: 0 6px 8px rgba(0,0,0,0.1); /* Optional: Adds a subtle shadow for a lifted effect */
+        width: 55%; /* Adjust width as needed */
+        row-gap: 30px;
     }
 
-    .sidebar-image {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 100%; /* Ensure the image container takes full width */
-        padding-top: 20px;
-    }
-
-    .sidebar-image img {
-        border-radius: 50%;
-        width: 100%;
-        height: 100%;
-        max-width: 350px;
-        /* overflow: hidden; */
-    }
-
-    .top-bar-text {
-        display: flex;
-        text-align: left;
-        justify-content: flex-start;
-        font-size: 20px;
-        padding: 20px;
-        margin: 0;
-        padding-top: 20px;
+    .intro-banner {
+        width: 55%;
     }
 
     .posts {
@@ -419,52 +445,14 @@ main {
     /* Flex container to hold the two sections */
     .flex-container {
         display: flex;
-        column-gap: 30px;
-        width: 80%; /* Adjust width as needed */
-        justify-content: center;
-        flex-direction: row;
-        vertical-align: top;
-    }
-
-    .top-bar {
-        display: flex;
         flex-direction: column;
-        gap: 20px;
         align-items: center;
-        background-color: #333;
-        color: #fff;
-        width: 45%;
-        border-radius: 8px; /* Rounded corners */
-        box-shadow: 0 6px 8px rgba(0,0,0,0.1);
-        padding: 20px;
-        border: 1px solid #dbd8cd; /* Adjust the color and thickness as desired */
-        border-radius: 8px; /* This rounds the corners. Adjust as desired. */
-        box-sizing: border-box;
-        box-shadow: 0 6px 8px rgba(0,0,0,0.1); /* Optional: Adds a subtle shadow for a lifted effect */
+        width: 80%; /* Adjust width as needed */
+        row-gap: 30px;
     }
 
-    .sidebar-image {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 100%; /* Ensure the image container takes full width */
-    }
-
-    .sidebar-image img {
-        border-radius: 50%;
-        width: 100%;
-        height: 100%;
-        max-width: 350px;
-        /* overflow: hidden; */
-    }
-
-    .top-bar-text {
-        display: flex;
-        text-align: left;
-        justify-content: flex-start;
-        font-size: 18px;
-        padding: 10px;
-        margin: 0;
+    .intro-banner {
+        width: 80%;
     }
 
     .posts {
@@ -716,50 +704,8 @@ main {
         vertical-align: top;
     }
 
-    .top-bar {
-        display: flex;
-        background-color: #333;
-        flex-direction: row;
-        color: #fff;
-        width: 100%;
-        height: auto;
-        align-items: center;
-        justify-content: center;
-        border: 1px solid #dbd8cd; /* Adjust the color and thickness as desired */
-        border-radius: 8px; /* This rounds the corners. Adjust as desired. */
-        padding: 18px; /* Provides some space between the border and the card content. Adjust as desired. */
-        box-sizing: border-box;
-        box-shadow: 0 6px 8px rgba(0,0,0,0.1); /* Optional: Adds a subtle shadow for a lifted effect */
-        /* margin-bottom: 30px; Adds space below each card. Adjust as desired. */
-    }
-
-    .sidebar-image {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 40%;
-    }
-
-    .sidebar-image img {
-        display: flex; /* This makes the image center inside the container */
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        border-radius: 50%;
-        overflow: hidden;
-    }
-
-    .top-bar-text {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        flex: 1;  /* Takes up the remaining space in the .post-card */
-        padding-right: 20px;
-        padding-left: 20px;
-        vertical-align: center;
-        width: 60%;
-        font-size: 16px;
-        /* height: 100%; Takes up the full height of the post card */
+    .intro-banner {
+        width: 85%;
     }
 
 
@@ -1003,65 +949,20 @@ main {
         max-width: 500px;
     }
 
-    .top-bar {
-        display: flex;
-        background-color: #333;
-        color: #fff;
-        justify-content: space-between;
-        width: 100%;
-        height: auto;
-        flex-direction: column;
-        align-items: center;
-        margin-bottom: 30px;
-        border: 1px solid #dbd8cd; /* Adjust the color and thickness as desired */
-        border-radius: 8px; /* This rounds the corners. Adjust as desired. */
-        padding: 18px; /* Provides some space between the border and the card content. Adjust as desired. */
-        box-sizing: border-box;
-        box-shadow: 0 6px 8px rgba(0,0,0,0.1); /* Optional: Adds a subtle shadow for a lifted effect */
-        /* margin-bottom: 30px; Adds space below each card. Adjust as desired. */
-    }
-
-    .sidebar-image {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        max-width: 300px;
-    }
-
-    .sidebar-image img {
-        display: flex; /* This makes the image center inside the container */
-        align-items: center;
-        justify-content: center;
-        border-radius: 50%;
-        width: 100%;
-        height: 100%;
-        margin-top: 0px;
-        margin-bottom: 0px;
-        overflow: hidden;
-    }
-
     /* Flex container to hold the two sections */
     .flex-container {
         display: flex;
         flex-direction: column;
         align-items: center;
-        column-gap: 30px;
+        gap: 30px;
         width: 100%; /* Adjust width as needed */
         justify-content: center;
         vertical-align: top;
     }
 
-    .top-bar-text {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        flex: 1;  /* Takes up the remaining space in the .post-card */
-        padding-right: 20px;
-        padding-left: 20px;
+    .intro-banner {
         width: 100%;
-        vertical-align: center;
-        /* height: 100%; Takes up the full height of the post card */
+        margin-bottom: 30px;
     }
 
 

--- a/blog/templates/blog/blog_layout.html
+++ b/blog/templates/blog/blog_layout.html
@@ -7,17 +7,18 @@
 
 {% block content %}
 <div class="centered-content">
-    <div class="flex-container">
-        <!-- Top bar -->
-        <div class="top-bar">
-            <div class="sidebar-image">
-                <img src="https://avatars.githubusercontent.com/u/48101971?v=4" alt="GitHub Profile Image" class="img-fluid">
+    <section class="intro-banner">
+        <div class="intro-banner-content">
+            <div class="intro-avatar">
+                <img src="https://avatars.githubusercontent.com/u/48101971?v=4" alt="GitHub profile picture" class="img-fluid">
             </div>
-            <div class="top-bar-text">
-                <p>I'm Justin. <br><br>This site will be a collection of notes, write-ups, projects, thought out posts, garbage, and occassional breakthroughs. Mostly about data.</p>
+            <div class="intro-text">
+                <p>I'm Justin.<br><br>This site will be a collection of notes, write-ups, projects, thought out posts, garbage, and occasional breakthroughs. Mostly about data.</p>
             </div>
         </div>
+    </section>
 
+    <div class="flex-container">
         <!-- Main Content -->
         <div class="posts">
             {% for post in posts %}


### PR DESCRIPTION
## Summary
- move the intro content out of the sidebar and render it as a full-width banner above the blog post list
- add new styling for the banner with a softer background, tighter avatar, and responsive tweaks across breakpoints

## Testing
- `python manage.py check` *(fails: missing environment variables such as ALLOWED_HOSTS and STATIC_ROOT)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ccfd8fd6c8323ade4e9da77452c24)